### PR TITLE
Potential fix for code scanning alert no. 1 and 2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/scripts/import-flickr.mjs
+++ b/scripts/import-flickr.mjs
@@ -66,10 +66,13 @@ function parseGeo(geo) {
 
 function escapeYaml(str) {
   if (!str) return '""';
-  if (str.includes('"') || str.includes(':') || str.includes('#') || str.includes('\n')) {
-    return `"${str.replace(/"/g, '\\"')}"`;
-  }
-  return `"${str}"`;
+  const escaped = str
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
 }
 
 async function main() {


### PR DESCRIPTION
Potential fix for [https://github.com/andystevensname/andystevens.name/security/code-scanning/2](https://github.com/andystevensname/andystevens.name/security/code-scanning/2)

General fix: when constructing YAML double-quoted strings manually, escape backslashes first, then escape double quotes, and normalize control characters that should be represented as escapes (at least newlines).

Best minimal fix without changing behavior broadly: update `escapeYaml` in `scripts/import-flickr.mjs` so it always returns a double-quoted YAML string and safely escapes:
- `\` → `\\`
- `"` → `\"`
- newline chars (`\n`, optionally `\r`, `\t`) to escaped sequences

This directly resolves CodeQL’s flagged issue on line 70 and keeps current output style (double-quoted YAML strings). No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
